### PR TITLE
Added example - display errors after lint

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,9 @@ linter.lint('./test.styl', 'content');
 
 // if you want check file
 linter.lint('./test.styl');
+
+// and display errors.
+linter.display();
 ```
 
 ## Config file


### PR DESCRIPTION
If you only used the lint method, because don't know whether it is working properly.